### PR TITLE
Remove old theme keywords & add USGS Thesaurus

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: meddle
 Title: Metadata generation for data releases
-Version: 0.0.13
-Date: 2020-11-18
+Version: 0.0.14
+Date: 2021-01-22
 Authors@R: c(person("Jordan", "Read", email = "jread@usgs.gov", role = c("aut", "cre")),
   person("Aaron", "Berdanier", email = "aaron.berdanier@duke.edu", role = c("aut")),
   person("Jordan", "Walker", email = "jiwalker@usgs.gov", role = c("aut")),

--- a/inst/extdata/FGDC_template.mustache
+++ b/inst/extdata/FGDC_template.mustache
@@ -68,8 +68,6 @@
         <themekt>ISO 19115 Topic Category</themekt>
         <themekey>environment</themekey>
         <themekey>inlandWaters</themekey>
-        <themekey>007</themekey>
-        <themekey>012</themekey>
       </theme>
       <place>
         <placekt>Department of Commerce, 1995, Countries, Dependencies, Areas of Special Sovereignty, and Their Principal Administrative Divisions,  Federal Information Processing Standard (FIPS) 10-4, Washington, D.C., National Institute of Standards and Technology</placekt>

--- a/inst/extdata/FGDC_template.mustache
+++ b/inst/extdata/FGDC_template.mustache
@@ -69,6 +69,10 @@
         <themekey>environment</themekey>
         <themekey>inlandWaters</themekey>
       </theme>
+      <theme>
+        <themekt>USGS Thesaurus</themekt>
+        <themekey>water resources</themekey>
+      </theme>
       <place>
         <placekt>Department of Commerce, 1995, Countries, Dependencies, Areas of Special Sovereignty, and Their Principal Administrative Divisions,  Federal Information Processing Standard (FIPS) 10-4, Washington, D.C., National Institute of Standards and Technology</placekt>
         <placekey>United States</placekey>


### PR DESCRIPTION
Per [the discussion in the mntoha data release repo](https://github.com/USGS-R/mntoha-data-release/pull/24#issuecomment-765572735), we need to edit the FGDC template. I added the USGS Thesaurus, but only used the one keyword from [Alison's example](https://github.com/USGS-R/mntoha-data-release/pull/24#issuecomment-765461683) because it is more broadly applicable to our projects.

This addresses #66 and does the easy part of #67, where we add the USGS Thesaurus but don't make things more flexible.  