### PR TITLE
add a `form` field for cross-cites

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: meddle
 Title: Metadata generation for data releases
-Version: 0.0.15
-Date: 2021-01-22
+Version: 0.0.16
+Date: 2021-07-13
 Authors@R: c(person("Jordan", "Read", email = "jread@usgs.gov", role = c("aut", "cre")),
   person("Aaron", "Berdanier", email = "aaron.berdanier@duke.edu", role = c("aut")),
   person("Jordan", "Walker", email = "jiwalker@usgs.gov", role = c("aut")),

--- a/inst/extdata/FGDC_template.mustache
+++ b/inst/extdata/FGDC_template.mustache
@@ -18,15 +18,15 @@
     <citeinfo>
       {{#authors}}
       <origin>{{.}}</origin>
-      {{/authors}} 
+      {{/authors}}
       <pubdate>{{pubdate}}</pubdate>
       <title>{{title}}</title>
       {{#form}}
       <geoform>{{.}}</geoform>
-      {{/form}} 
+      {{/form}}
       {{#link}}
       <onlink>{{.}}</onlink>
-      {{/link}} 
+      {{/link}}
     </citeinfo>
   </lworkcit>
 {{/larger-cites}}
@@ -113,12 +113,15 @@
     <citeinfo>
       {{#authors}}
       <origin>{{.}}</origin>
-      {{/authors}} 
+      {{/authors}}
       <pubdate>{{pubdate}}</pubdate>
       <title>{{title}}</title>
+      {{#form}}
+      <geoform>{{.}}</geoform>
+      {{/form}}
       {{#link}}
       <onlink>{{.}}</onlink>
-      {{/link}} 
+      {{/link}}
     </citeinfo>
   </crossref>
 {{/cross-cites}}


### PR DESCRIPTION
Without this field, the Metadata Wizard throws an error for any cross reference along the lines of 

> the value for Geospatial Data Presentation Form (geoform) cannot be empty

This is because even if you had `form: ` in the yml file, it wouldn't get pulled into the resulting XML. This was discovered while working on [the multistate GLM data release](https://github.com/jread-usgs/hyperscales-data-release/issues/26#issuecomment-879357598) and [the MN TOHA data release](https://github.com/USGS-R/mntoha-data-release/issues/56#issuecomment-879357086).