### PR TITLE
FGDC standards update + yaml package change default behavior

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -27,7 +27,7 @@ render <- function(data, filename, ...){
 #' @export
 render.character <- function(data, filename, ..., template){
   stopifnot(file.exists(data))
-  config.text <- yaml::yaml.load_file(data)
+  config.text <- yaml::yaml.load_file(data, eval.expr = TRUE)
   current.dir <- getwd()
   # setting working directory to the file that is being used, evaluation will be relative to that directory
   setwd(dirname(data))

--- a/inst/extdata/FGDC_template.mustache
+++ b/inst/extdata/FGDC_template.mustache
@@ -50,7 +50,6 @@
       <update>{{update}}</update>
     </status>
     <spdom>
-      <descgeog>{{descgeog}}</descgeog>
       <bounding>
         <westbc>{{wbbox}}</westbc>
         <eastbc>{{ebbox}}</eastbc>


### PR DESCRIPTION
With the field descgeog populated, we get an informative error and warning from the FGDC metadata check. 
![image](https://user-images.githubusercontent.com/15788176/168150393-66780e9d-73cb-4583-860c-e780d1ca57d5.png)

The error is saying it no longer expects the description in the spatial domain section, and I can't find anywhere else it is supposed to be. The warning is saying the bounding box is out of order -- it is expecting the bounding box field to be first in the spatial domain section. Manually removing descgeog field from the same xml file produces the following FGDC check: 

Additionally, `yaml::yaml.load` changed default behavior to not automatically convert expressions. See this change: https://github.com/vubiostat/r-yaml/commit/d236f9a0ab821f88e2ca855fb48ae4ccc8e16923