### PR TITLE
remove field Description_of_Geographic_Extent

### DIFF
--- a/inst/extdata/FGDC_template.mustache
+++ b/inst/extdata/FGDC_template.mustache
@@ -50,7 +50,6 @@
       <update>{{update}}</update>
     </status>
     <spdom>
-      <descgeog>{{descgeog}}</descgeog>
       <bounding>
         <westbc>{{wbbox}}</westbc>
         <eastbc>{{ebbox}}</eastbc>


### PR DESCRIPTION
Confirmed with Sciencebase on 2022-05-23 that this field is no longer required, and produces an informative error with the FGDC metadata checker. Without this field, SB confirmed the metadata still passes their check.