### PR TITLE
improve YAML validation

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -33,6 +33,13 @@ render.character <- function(data, filename, ..., template){
   setwd(dirname(data))
   external.resources <- config.text[['external']]
   config.text[['external']] <- NULL # for the time being
+  undefined_elements = which(unlist(lapply(config.text, is.null)))
+  if (length(undefined_elements) > 0) {
+    stop(paste("All elements of the YAML file must be defined. The following",
+               "elements are blank:",
+               paste(names(undefined_elements), collapse = ", "))
+    )
+  }
   tryCatch({
     # evaluate any function calls
     config.text <- lapply(config.text, eval_content)

--- a/R/render.R
+++ b/R/render.R
@@ -33,7 +33,7 @@ render.character <- function(data, filename, ..., template){
   setwd(dirname(data))
   external.resources <- config.text[['external']]
   config.text[['external']] <- NULL # for the time being
-  undefined_elements = which(unlist(lapply(config.text, is.null)))
+  undefined_elements <-  which(unlist(lapply(config.text, is.null)))
   if (length(undefined_elements) > 0) {
     stop(paste("All elements of the YAML file must be defined. The following",
                "elements are blank:",


### PR DESCRIPTION
When `render` is given a YAML file which has empty elements, it fails in a very unfriendly way. Example, which arose from [this YAML file](https://github.com/USGS-R/drb-estuary-salinity-ml-data-release/blob/480c301b4b5d50f91bdc7d9d0be8a404973fbecf/in_text/text_data_release.yml#L271):

![image](https://user-images.githubusercontent.com/13890601/231903567-a8272f58-4701-438f-87eb-b3c4bb1e4940.png)

This PR adds a test for empty elements, and gives a descriptive error message if there are any.

I'm calling this a draft because I haven't done a data release before, and I'm not sure that this is the right approach. Possibly the right approach might be to trim any empty values rather than failing?