### PR TITLE
fix installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     whisker,
     sf (>= 0.9.6),
     sp,
+    spData,
     xml2 (>= 1.0.0),
     tools,
     utils,


### PR DESCRIPTION
When trying to install this on a fresh R, I got an error:

> Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) :
>    there is no package called ‘spData’

because the package imports `spData` but it's not in the `DESCRIPTION` file.

This PR fixes that.

### How to test

You could start a fresh `renv` and try the following to make sure the installation is smooth:

```r
install.packages("remotes")
remotes::install_github("jesse-ross/meddle@fix-description-file", upgrade = "never")
```